### PR TITLE
DE-2120: Remove problematic import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,16 @@
 
 from distutils.core import setup
 
-import spc
+__author__ = "Rohan Isaac"
+__author_email__ = "rohan_isaac@yahoo.com"
+__version__ = "0.4.0"
+__license__ = "GPLv3"
 
 setup(name='spc',
-      version=spc.__version__,
-      description=spc.__doc__,
-      author=spc.__author__,
-      author_email=spc.__author_email__,
+      version=__version__,
+      description=__doc__,
+      author=__author__,
+      author_email=__author_email__,
       url='https://github.com/rohanisaac/spc',
       packages=['spc'],
       install_requires=['numpy'],

--- a/spc/__init__.py
+++ b/spc/__init__.py
@@ -3,8 +3,3 @@ Module for reading, exploring and converting SPC spectroscopic binary data in Py
 """
 
 from .spc import File
-
-__author__ = "Rohan Isaac"
-__author_email__ = "rohan_isaac@yahoo.com"
-__version__ = "0.4.0"
-__license__ = "GPLv3"


### PR DESCRIPTION
In `setup.py`, there's an `import spc` present that requires numpy to be installed before the setup can actually install it. This import is just to set some package information, so I just moved values that defined this directly into `setup.py`.